### PR TITLE
Simplify BLE Connection

### DIFF
--- a/Firmware/main/BLESerial.cpp
+++ b/Firmware/main/BLESerial.cpp
@@ -5,6 +5,9 @@ Header: BLESerial.h
 
 #include "BLESerial.h"
 
+#define SERVICE_UUID_CUSTOMLITT   "9F170001-899F-4F35-AD8A-85DF24B12007"
+#define CHARACTERISTIC_UUID_CL_ID "9F170002-899F-4F35-AD8A-85DF24B12007"
+
 #define SERVICE_UUID           "6E400001-B5A3-F393-E0A9-E50E24DCCA9E" // UART service UUID
 #define CHARACTERISTIC_UUID_RX "6E400002-B5A3-F393-E0A9-E50E24DCCA9E"
 #define CHARACTERISTIC_UUID_TX "6E400003-B5A3-F393-E0A9-E50E24DCCA9E"
@@ -45,9 +48,15 @@ bool BLESerial::begin(const char* localName="UART Service"){
   pServer->setCallbacks(new BLESerialServerCallbacks());
 
   // Create the BLE Service
+  pCustomLittService = pServer->createService(SERVICE_UUID_CUSTOMLITT);
   pService = pServer->createService(SERVICE_UUID);
 
   // Create a BLE Characteristic
+  pCustomLittIdCharacteristic = pCustomLittService->createCharacteristic(
+                    CHARACTERISTIC_UUID_CL_ID,
+                    BLECharacteristic::PROPERTY_READ
+                  );
+                  
   pTxCharacteristic = pService->createCharacteristic(
 										CHARACTERISTIC_UUID_TX,
 										BLECharacteristic::PROPERTY_NOTIFY
@@ -64,6 +73,7 @@ bool BLESerial::begin(const char* localName="UART Service"){
   pService->start();
 
   // Start advertising
+  pServer->getAdvertising()->addServiceUUID(SERVICE_UUID_CUSTOMLITT);
   pServer->getAdvertising()->start();
   return true;
 }

--- a/Firmware/main/BLESerial.cpp
+++ b/Firmware/main/BLESerial.cpp
@@ -69,7 +69,8 @@ bool BLESerial::begin(const char* localName="UART Service"){
 										);
   pRxCharacteristic->setCallbacks(new NUSCallbacks(this));
 
-  // Start the service
+  // Start the service(s)
+  pCustomLittService->start();
   pService->start();
 
   // Start advertising

--- a/Firmware/main/BLESerial.h
+++ b/Firmware/main/BLESerial.h
@@ -91,6 +91,10 @@ private:
   String local_name;
 
   BLEServer *pServer = NULL;
+  
+  BLEService *pCustomLittService = NULL;
+  BLECharacteristic * pCustomLittIdCharacteristic = NULL;
+  
   BLEService *pService = NULL;
   BLECharacteristic * pTxCharacteristic = NULL;
   BLECharacteristic * pRxCharacteristic = NULL;


### PR DESCRIPTION
This PR makes it very easy for users to find and connect to their device.

Adds another service to the BLE server with a brand-new UUID for the CustomLitt product. Adds that UUID to the advertising data which then works in conjunction with the app to filter out other devices. That way the user sees only available CustomLitt devices in the connection menu.